### PR TITLE
Add semestral periodicity option

### DIFF
--- a/app.py
+++ b/app.py
@@ -224,6 +224,9 @@ def bono_flow(id_valoracion):
     if periodicidad == "trimestral":
         freq = 4
         step = 3
+    elif periodicidad == "semestral":
+        freq = 2
+        step = 6
     else:
         freq = 12
         step = 1

--- a/templates/edit_bono.html
+++ b/templates/edit_bono.html
@@ -27,6 +27,7 @@
               <label for="periodicidad" class="form-label">Periodicidad de Pago</label>
               <select class="form-select" id="periodicidad" name="periodicidad" title="Frecuencia de pagos">
                 <option value="mensual" {% if bono.periodicidad=='mensual' %}selected{% endif %}>Mensual</option>
+                <option value="semestral" {% if bono.periodicidad=='semestral' %}selected{% endif %}>Semestral</option>
                 <option value="trimestral" {% if bono.periodicidad=='trimestral' %}selected{% endif %}>Trimestral</option>
               </select>
             </div>

--- a/templates/help.html
+++ b/templates/help.html
@@ -18,7 +18,7 @@
           <dd class="col-sm-8">Duración total del bono, en meses.</dd>
 
           <dt class="col-sm-4">Periodicidad de Pago</dt>
-          <dd class="col-sm-8">Frecuencia con la que se realizan los pagos: mensual o trimestral.</dd>
+          <dd class="col-sm-8">Frecuencia con la que se realizan los pagos: mensual, semestral o trimestral.</dd>
 
           <dt class="col-sm-4">Plazo de Gracia</dt>
           <dd class="col-sm-8">

--- a/templates/new_bono.html
+++ b/templates/new_bono.html
@@ -24,6 +24,7 @@
               <label for="periodicidad" class="form-label">Periodicidad de Pago</label>
               <select class="form-select" id="periodicidad" name="periodicidad" title="Frecuencia de pagos">
                 <option value="mensual">Mensual</option>
+                <option value="semestral">Semestral</option>
                 <option value="trimestral">Trimestral</option>
               </select>
             </div>


### PR DESCRIPTION
## Summary
- add "semestral" option in periodicidad selects
- update help page with the new frequency
- support semestral calculation in flask backend

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6860f95159b0832382f861f87995b11c