### PR TITLE
Format monetary amounts with thousands separators

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,14 @@ app.secret_key = "cámbiala_por_una_clave_segura"  # Para sesiones y flash messa
 
 DB_PATH = "database.db"
 
+# Filtro para formatear montos con separador de miles
+@app.template_filter('money')
+def money_filter(value):
+    try:
+        return "{:,.2f}".format(float(value))
+    except (ValueError, TypeError):
+        return value
+
 def init_db():
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()

--- a/templates/flow.html
+++ b/templates/flow.html
@@ -8,7 +8,7 @@
   <div class="col-12">
     <h2 class="mb-3 text-center">Flujo de Caja - Valoración #{{ bono.id_valoracion }}</h2>
     <ul class="list-group mb-4">
-      <li class="list-group-item"><strong>Monto inicial:</strong> {{ symbol }} {{ bono.monto_bono }}</li>
+      <li class="list-group-item"><strong>Monto inicial:</strong> {{ symbol }} {{ bono.monto_bono|money }}</li>
       <li class="list-group-item"><strong>Moneda:</strong> {{ currency }}</li>
       <li class="list-group-item"><strong>Tipo de tasa:</strong> {{ rate_type }}</li>
       {% if rate_type == 'nominal' %}
@@ -18,10 +18,10 @@
       <li class="list-group-item"><strong>Tasa periódica:</strong> {{ tasa_periodica }}%</li>
       <li class="list-group-item"><strong>Periodicidad:</strong> {{ bono.periodicidad }}</li>
       <li class="list-group-item"><strong>Plazo de Gracia:</strong> {{ bono.plazo_gracia }}</li>
-      <li class="list-group-item"><strong>Precio de compra:</strong> 
-        {% if bono.precio_compra %}{{ symbol }} {{ bono.precio_compra }}{% else %}(no proporcionado){% endif %}
+      <li class="list-group-item"><strong>Precio de compra:</strong>
+        {% if bono.precio_compra %}{{ symbol }} {{ bono.precio_compra|money }}{% else %}(no proporcionado){% endif %}
       </li>
-      <li class="list-group-item"><strong>Precio máximo (VPN):</strong> {{ symbol }} {{ price_max }}</li>
+      <li class="list-group-item"><strong>Precio máximo (VPN):</strong> {{ symbol }} {{ price_max|money }}</li>
     </ul>
 
     <h3 class="mb-3">Indicadores Financieros</h3>
@@ -51,11 +51,11 @@
           {% for row in flujo %}
           <tr>
             <td>{{ row.periodo }}</td>
-            <td>{{ symbol }} {{ row.saldo_ini }}</td>
-            <td>{{ symbol }} {{ row.cuota }}</td>
-            <td>{{ symbol }} {{ row.interes }}</td>
-            <td>{{ symbol }} {{ row.amortizacion }}</td>
-            <td>{{ symbol }} {{ row.saldo_fin }}</td>
+            <td>{{ symbol }} {{ row.saldo_ini|money }}</td>
+            <td>{{ symbol }} {{ row.cuota|money }}</td>
+            <td>{{ symbol }} {{ row.interes|money }}</td>
+            <td>{{ symbol }} {{ row.amortizacion|money }}</td>
+            <td>{{ symbol }} {{ row.saldo_fin|money }}</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/templates/home.html
+++ b/templates/home.html
@@ -31,7 +31,7 @@
       {% for v in valoraciones %}
         {% set symbol = {'PEN':'S/','USD':'$','EUR':'€'}.get(v.currency, v.currency) %}
         <tr>
-          <td>{{ symbol }} {{ v.monto_bono }}</td>
+          <td>{{ symbol }} {{ v.monto_bono|money }}</td>
           <td>{{ v.tasa_anual }}%</td>
           <td>{{ v.plazo_meses }}</td>
           <td>{{ v.periodicidad }}</td>


### PR DESCRIPTION
## Summary
- create Jinja filter `money` to format amounts with commas
- apply the new filter on the home listing
- apply the new filter on the cash flow detail page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6861014f4434832380d70496516131b3