### PR TITLE
Add DB initialization script and refactor SQLite handling

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -1,0 +1,29 @@
+import hashlib
+import sqlite3
+from app import DB_PATH, init_db
+
+
+def reset_db():
+    """Erase all data and create default admin user."""
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+
+    tables = cur.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
+    ).fetchall()
+    for (table,) in tables:
+        cur.execute(f"DELETE FROM {table}")
+
+    password = hashlib.sha256("admin".encode()).hexdigest()
+    cur.execute(
+        "INSERT INTO users (name, email, password) VALUES (?, ?, ?)",
+        ("Admin", "admin@email.com", password),
+    )
+    conn.commit()
+    conn.close()
+    print("Database cleaned and default user created.")
+
+
+if __name__ == "__main__":
+    reset_db()


### PR DESCRIPTION
## Summary
- refactor login and register routes to reuse `get_db`
- clean duplicate imports and add environment-based run configuration
- add `initialize.py` helper to reset database and create default admin user

## Testing
- `python -m py_compile app.py initialize.py`

------
https://chatgpt.com/codex/tasks/task_e_68610ebed2548323a7139a9264fa3ec6