### PR TITLE
Add payment dates in bond flow tables

### DIFF
--- a/templates/edit_bono.html
+++ b/templates/edit_bono.html
@@ -24,6 +24,10 @@
                      value="{{ bono.plazo_meses }}" title="Duración del bono en meses">
             </div>
             <div class="col-md-4">
+              <label for="start_date" class="form-label">Fecha de Emisión</label>
+              <input type="date" class="form-control" id="start_date" name="start_date" value="{{ bono.start_date }}" required>
+            </div>
+            <div class="col-md-4">
               <label for="periodicidad" class="form-label">Periodicidad de Pago</label>
               <select class="form-select" id="periodicidad" name="periodicidad" title="Frecuencia de pagos">
                 <option value="mensual" {% if bono.periodicidad=='mensual' %}selected{% endif %}>Mensual</option>

--- a/templates/flow.html
+++ b/templates/flow.html
@@ -40,6 +40,7 @@
         <thead class="table-dark">
           <tr>
             <th>Periodo</th>
+            <th>Fecha Pago</th>
             <th>Saldo Inicial</th>
             <th>Cuota</th>
             <th>Interés</th>
@@ -51,6 +52,7 @@
           {% for row in flujo %}
           <tr>
             <td>{{ row.periodo }}</td>
+            <td>{{ row.fecha_pago }}</td>
             <td>{{ symbol }} {{ row.saldo_ini|money }}</td>
             <td>{{ symbol }} {{ row.cuota|money }}</td>
             <td>{{ symbol }} {{ row.interes|money }}</td>

--- a/templates/new_bono.html
+++ b/templates/new_bono.html
@@ -21,6 +21,10 @@
               <input type="number" class="form-control" id="plazo_meses" name="plazo_meses" required title="Duración del bono en meses">
             </div>
             <div class="col-md-4">
+              <label for="start_date" class="form-label">Fecha de Emisión</label>
+              <input type="date" class="form-control" id="start_date" name="start_date" required>
+            </div>
+            <div class="col-md-4">
               <label for="periodicidad" class="form-label">Periodicidad de Pago</label>
               <select class="form-select" id="periodicidad" name="periodicidad" title="Frecuencia de pagos">
                 <option value="mensual">Mensual</option>


### PR DESCRIPTION
## Summary
- store start date for bonds
- compute payment dates for each flow
- show payment dates in results table

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6861cfc541408323a4e5155a2a589a05